### PR TITLE
Supressing warning in Robot.java

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -36,6 +36,7 @@ public class Robot extends LoggedRobot {
    * initialization code.
    */
   @Override
+  @SuppressWarnings("resource") // Supresses warnings in method related to resources ("new PowerDistribution")
   public void robotInit() {
 
     Logger.recordMetadata("ProjectName", "MyProject"); // Set a metadata value


### PR DESCRIPTION
The warning is redundant and should be ignored. Will not affect execution of code.